### PR TITLE
Bump nodegit to 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
-    "nodegit": "^0.11.6",
+    "nodegit": "^0.14.1",
     "temp": "^0.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I had a project that had `nodegit` blowing up when trying to use `npm-git-install`, so I forked it and bumped the `nodegit` version.
